### PR TITLE
Construct Error::RecordNotFound when record not found

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -10,6 +10,7 @@ use std::{
 use memmap::Mmap;
 
 use crate::{consts, error, record};
+use crate::error::Error;
 
 #[derive(Debug)]
 struct UnopenedDB {
@@ -237,7 +238,7 @@ impl DB {
                 }
             }
         }
-        Err("no record found".into())
+        Err(Error::RecordNotFound)
     }
 
     fn ipv6_lookup(&mut self, ipv6: Ipv6Addr) -> Result<record::Record, error::Error> {
@@ -268,7 +269,7 @@ impl DB {
                 }
             }
         }
-        Err("no record found".into())
+        Err(Error::RecordNotFound)
     }
 
     fn read_record(&mut self, row_addr: u32) -> Result<record::Record, error::Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::{fmt, io};
 pub enum Error {
     GenericError(String),
     IoError(String),
-    RecordNotFound(String),
+    RecordNotFound,
     InvalidIP(String),
 }
 
@@ -43,7 +43,7 @@ impl fmt::Debug for Error {
         match self {
             Error::GenericError(msg) => write!(f, "GenericError: {}", msg)?,
             Error::IoError(msg) => write!(f, "IoError: {}", msg)?,
-            Error::RecordNotFound(msg) => write!(f, "RecordNotFound: {}", msg)?,
+            Error::RecordNotFound => write!(f, "RecordNotFound: no record found")?,
             Error::InvalidIP(msg) => write!(f, "InvalidIP: {}", msg)?,
         }
         Ok(())

--- a/src/tests/tests_error.rs
+++ b/src/tests/tests_error.rs
@@ -18,7 +18,7 @@ fn test_error_display() {
     );
 
     assert_eq!(
-        format!("{:?}", Error::RecordNotFound("no record found".to_string())),
+        format!("{:?}", Error::RecordNotFound),
         "RecordNotFound: no record found".to_string()
     );
 


### PR DESCRIPTION
Previously a `GenericError` was created. Since the `String` it was carrying never included any extra detail I dropped it.