### PR TITLE
Link crates badge to crate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Rust IP2Location
 -----------------
-![Crates.io](https://img.shields.io/crates/v/ip2location)
+[![Crates.io](https://img.shields.io/crates/v/ip2location)](https://crates.io/crates/ip2location)
 [![Documentation](https://docs.rs/ip2location/badge.svg)](https://docs.rs/ip2location/0.1.0/ip2location/struct.DB.html)
 [![Build Status](https://travis-ci.com/marirs/rust-ip2location.svg?branch=main)](https://travis-ci.com/marirs/rust-ip2location)
 


### PR DESCRIPTION
Sorry for another small PR, I just noticed this when I clicked on the badge.