### PR TITLE
Accept IpAddr instead of &str in ip_lookup

### DIFF
--- a/examples/lookup.rs
+++ b/examples/lookup.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), String> {
     println!();
 
     // print the IP information
-    match db.ip_lookup(&*ip.to_string()) {
+    match db.ip_lookup(ip) {
         Ok(record) => println!("{:#?}", record),
         Err(e) => println!("{:?}", e),
     };

--- a/examples/lookup_mmap.rs
+++ b/examples/lookup_mmap.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), String> {
     println!();
 
     // print the IP information
-    match db.ip_lookup(&*ip.to_string()) {
+    match db.ip_lookup(ip) {
         Ok(record) => println!("{:#?}", record),
         Err(e) => println!("{:?}", e),
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ pub enum Error {
     GenericError(String),
     IoError(String),
     RecordNotFound,
-    InvalidIP(String),
 }
 
 impl From<io::Error> for Error {
@@ -44,7 +43,6 @@ impl fmt::Debug for Error {
             Error::GenericError(msg) => write!(f, "GenericError: {}", msg)?,
             Error::IoError(msg) => write!(f, "IoError: {}", msg)?,
             Error::RecordNotFound => write!(f, "RecordNotFound: no record found")?,
-            Error::InvalidIP(msg) => write!(f, "InvalidIP: {}", msg)?,
         }
         Ok(())
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv6Addr};
+
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
@@ -8,9 +10,9 @@ pub struct Country {
 }
 
 #[skip_serializing_none]
-#[derive(PartialEq, Debug, Default, Clone, Serialize)]
+#[derive(PartialEq, Debug, Clone, Serialize)]
 pub struct Record {
-    pub ip: String,
+    pub ip: IpAddr,
     pub latitude: Option<f32>,
     pub longitude: Option<f32>,
     pub country: Option<Country>,
@@ -35,5 +37,32 @@ pub struct Record {
 impl Record {
     pub fn to_json(&self) -> String {
         serde_json::to_string(&self).unwrap()
+    }
+}
+
+impl Default for Record {
+    fn default() -> Self {
+        Record {
+            ip: IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            latitude: None,
+            longitude: None,
+            country: None,
+            region: None,
+            city: None,
+            isp: None,
+            domain: None,
+            zip_code: None,
+            time_zone: None,
+            net_speed: None,
+            idd_code: None,
+            area_code: None,
+            weather_station_code: None,
+            weather_station_name: None,
+            mcc: None,
+            mnc: None,
+            mobile_brand: None,
+            elevation: None,
+            usage_type: None
+        }
     }
 }

--- a/src/tests/tests_error.rs
+++ b/src/tests/tests_error.rs
@@ -21,12 +21,4 @@ fn test_error_display() {
         format!("{:?}", Error::RecordNotFound),
         "RecordNotFound: no record found".to_string()
     );
-
-    assert_eq!(
-        format!(
-            "{:?}",
-            Error::InvalidIP("ip address is invalid".to_string())
-        ),
-        "InvalidIP: ip address is invalid".to_string()
-    );
 }

--- a/src/tests/tests_lib.rs
+++ b/src/tests/tests_lib.rs
@@ -6,7 +6,7 @@ const IPV6BIN: &str = "data/IP2LOCATION-LITE-DB1.IPV6.BIN";
 #[test]
 fn test_ipv4_lookup_in_ipv4bin() -> Result<(), error::Error> {
     let mut db = DB::from_file(IPV4BIN)?;
-    let record = db.ip_lookup("43.224.159.155")?;
+    let record = db.ip_lookup("43.224.159.155".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "IN");
     assert_eq!(record.country.unwrap().long_name, "India");
@@ -16,7 +16,7 @@ fn test_ipv4_lookup_in_ipv4bin() -> Result<(), error::Error> {
 #[test]
 fn test_ipv4_lookup_in_ipv4bin_using_mmap() -> Result<(), error::Error> {
     let mut db = DB::from_file_mmap(IPV4BIN)?;
-    let record = db.ip_lookup("43.224.159.155")?;
+    let record = db.ip_lookup("43.224.159.155".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "IN");
     assert_eq!(record.country.unwrap().long_name, "India");
@@ -26,7 +26,7 @@ fn test_ipv4_lookup_in_ipv4bin_using_mmap() -> Result<(), error::Error> {
 #[test]
 fn test_ipv4_lookup_in_ipv6bin() -> Result<(), error::Error> {
     let mut db = DB::from_file(IPV6BIN)?;
-    let record = db.ip_lookup("43.224.159.155")?;
+    let record = db.ip_lookup("43.224.159.155".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "IN");
     assert_eq!(record.country.unwrap().long_name, "India");
@@ -36,7 +36,7 @@ fn test_ipv4_lookup_in_ipv6bin() -> Result<(), error::Error> {
 #[test]
 fn test_ipv4_lookup_in_ipv6bin_using_mmap() -> Result<(), error::Error> {
     let mut db = DB::from_file_mmap(IPV6BIN)?;
-    let record = db.ip_lookup("43.224.159.155")?;
+    let record = db.ip_lookup("43.224.159.155".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "IN");
     assert_eq!(record.country.unwrap().long_name, "India");
@@ -46,7 +46,7 @@ fn test_ipv4_lookup_in_ipv6bin_using_mmap() -> Result<(), error::Error> {
 #[test]
 fn test_ipv6_lookup() -> Result<(), error::Error> {
     let mut db = DB::from_file(IPV6BIN)?;
-    let record = db.ip_lookup("2a01:b600:8001::")?;
+    let record = db.ip_lookup("2a01:b600:8001::".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "IT");
     assert_eq!(record.country.unwrap().long_name, "Italy");
@@ -56,7 +56,7 @@ fn test_ipv6_lookup() -> Result<(), error::Error> {
 #[test]
 fn test_ipv6_lookup_using_mmap() -> Result<(), error::Error> {
     let mut db = DB::from_file_mmap(IPV6BIN).unwrap();
-    let record = db.ip_lookup("2a01:cb08:8d14::")?;
+    let record = db.ip_lookup("2a01:cb08:8d14::".parse().unwrap())?;
     assert!(!record.country.is_none());
     assert_eq!(record.country.clone().unwrap().short_name, "FR");
     assert_eq!(record.country.unwrap().long_name, "France");
@@ -72,14 +72,5 @@ fn test_err_filenotfound() -> Result<(), error::Error> {
         "Error opening DB file: No such file or directory (os error 2)".to_string(),
     );
     assert_eq!(result, expected);
-    Ok(())
-}
-
-#[test]
-fn test_err_invalidipaddress() -> Result<(), error::Error> {
-    let mut db = DB::from_file(IPV4BIN)?;
-    let record = db.ip_lookup("invalid");
-    let expected = Err(error::Error::InvalidIP("ip address is invalid".to_string()));
-    assert_eq!(record, expected);
     Ok(())
 }


### PR DESCRIPTION
This PR changes `ip_lookup` to accept an `IpAddr`. My motivation for doing this was that the web framework I'm using provides the client ip as an `IpAddr` and without this change it would need to be be stringifed, only to be parsed again, then stringified again to be stored on the `Record`.

If the caller does only have a string, conversion is a fairly straightforward call to `parse`:

```rust
db.ip_lookup("2a01:cb08:8d14::".parse()?)
```