### PR TITLE
Replace `memmap` with `memmap2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/marirs/rust-ip2location"
 edition = "2021"
 
 [dependencies]
-memmap = "0.7.0"
+memmap2 = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "3.9.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use crate::{
     ip2location::{db::LocationDB, record::LocationRecord},
     ip2proxy::{db::ProxyDB, record::ProxyRecord},
 };
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{
     borrow::Cow,
     net::{IpAddr, Ipv6Addr},

--- a/src/ip2location/db.rs
+++ b/src/ip2location/db.rs
@@ -6,7 +6,7 @@ use crate::{
         record::{self, LocationRecord},
     },
 };
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{
     fs::File,
     net::{IpAddr, Ipv6Addr},

--- a/src/ip2proxy/db.rs
+++ b/src/ip2proxy/db.rs
@@ -6,7 +6,7 @@ use crate::{
         record::{Country, Proxy, ProxyRecord},
     },
 };
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{
     borrow::Cow,
     fs::File,


### PR DESCRIPTION
`memmap` is unmantained and caused [RUSTSEC-2020-0077](https://rustsec.org/advisories/RUSTSEC-2020-0077.html)